### PR TITLE
Add WarpSQL.blog to company blogs

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -219,6 +219,13 @@ url = https://planet-beta-pluto.oursqlcommunity.org/
   twitter = https://twitter.com/vettabase
   email = hello@vettabase.com
 
+[com_warpsql]
+  title = WarpSQL Blog
+  link = https://warpsql.blog
+  feed = https://warpsql.blog/feed/
+  twitter = justin_swanhart
+  email = jswanhart@yahoo.com
+
 #[com_]
 #  title = 
 #  link = 


### PR DESCRIPTION
Add the WarpSQL blog.  This blog is dedicated to the WarpSQL distribution of MySQL with the WARP storage engine.